### PR TITLE
ci: action touchups to improve release process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to crates.io
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json


### PR DESCRIPTION
## Why
- Improve release process and fix minor bugs

## Description
- Add workflow dispatch for cargo release
- Use PAT instead of GITHUB_TOKEN secret to allow release: published workflow trigger for release workflow

## Other Notes
- N/A
