### PR TITLE
ci: add goreleaser for release artifact builds

### DIFF
--- a/.github/workflows/upload-release-artifacts.yml
+++ b/.github/workflows/upload-release-artifacts.yml
@@ -7,10 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  packages: write
-  issues: write
-  id-token: write
+  contents: read
 
 jobs:
   goreleaser:
@@ -55,4 +52,4 @@ jobs:
           version: "~> v2"
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/upload-release-artifacts.yml
+++ b/.github/workflows/upload-release-artifacts.yml
@@ -1,0 +1,58 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - "*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: write
+  issues: write
+  id-token: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Set up Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      - name: Install cross-compilation dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            musl-tools \
+            musl-dev \
+            gcc-mingw-w64 \
+            gcc-mingw-w64-x86-64 \
+            gcc-aarch64-linux-gnu \
+            libc6-dev-arm64-cross \
+            build-essential
+
+      - name: 🦀 Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ tarpaulin-report.html
 
 .hooks/*
 !.hooks/pre-commit
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,63 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+before:
+  hooks:
+    # if you don't do these things before calling goreleaser, it might be a
+    # good idea to do them here:
+    - rustup default stable
+    - rustup target add x86_64-unknown-linux-gnu
+    - rustup target add x86_64-unknown-linux-musl
+    - rustup target add x86_64-apple-darwin
+    - rustup target add x86_64-pc-windows-gnu
+    - rustup target add aarch64-unknown-linux-gnu
+    - rustup target add aarch64-unknown-linux-musl
+    - rustup target add aarch64-apple-darwin
+    - cargo install --locked cargo-zigbuild
+    - cargo fetch --locked
+
+builds:
+  - builder: rust
+    flags:
+      - --release
+    targets:
+      - x86_64-unknown-linux-gnu
+      - x86_64-unknown-linux-musl
+      - x86_64-apple-darwin
+      - x86_64-pc-windows-gnu
+      - aarch64-unknown-linux-gnu
+      - aarch64-unknown-linux-musl
+      - aarch64-apple-darwin
+
+archives:
+  - formats: [tar.gz]
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}
+      {{- if contains .Target "musl" }}-musl{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+changelog:
+  disable: true
+
+release:
+  mode: keep-existing
+  github:
+    owner: jakepenzak
+    name: netbeat
+  draft: false
+  prerelease: auto


### PR DESCRIPTION
## Why
- Add release artifacts to releases

## Description
- Configured [goreleaser](https://goreleaser.com/) for efficient cross-compilation and publishing artifact buids 

## Other Notes
- N/A
